### PR TITLE
Added option to migrate attachments and set labels based on project name

### DIFF
--- a/src/github_issues/label_helper.py
+++ b/src/github_issues/label_helper.py
@@ -217,6 +217,11 @@ class LabelHelper:
         if category_label_name:
             label_names.append(category_label_name)
 
+        # Add project
+        project_label_name = self.get_label_from_id_name(redmine_issue_dict, 'project', 'Project:', non_formatted)
+        if project_label_name:
+            label_names.append(project_label_name)
+
         # Add component
         #   "custom_fields": [
         #        {

--- a/src/github_issues/migration_manager.py
+++ b/src/github_issues/migration_manager.py
@@ -28,6 +28,7 @@ class MigrationManager:
         
         self.include_comments = kwargs.get('include_comments', True)
         self.include_assignee = kwargs.get('include_assignee', True)
+        self.include_attachments = kwargs.get('include_attachments', True)
 
 
         self.user_mapping_filename = kwargs.get('user_mapping_filename', None)
@@ -196,6 +197,7 @@ class MigrationManager:
             json_fname_fullpath = os.path.join(self.redmine_json_directory, json_fname)
             gm_kwargs = { 'include_assignee' : self.include_assignee \
                          , 'include_comments' : self.include_comments \
+                         , 'include_attachments' : self.include_attachments \
                         }
             github_issue_number = gm.make_github_issue(json_fname_fullpath, **gm_kwargs)
         
@@ -215,6 +217,7 @@ if __name__=='__main__':
                 , redmine_issue_end_number=5000\
                 #, user_mapping_filename=USER_MAP_FILE       # optional
                 , include_assignee=False    # Optional. Assignee must be in the github repo and USER_MAP_FILE above
+                , include_attachments=True                  # optional
                 , label_mapping_filename=LABEL_MAP_FILE     # optional
                 #, milestone_mapping_filename=MILESTONE_MAP_FILE # optional
             )

--- a/src/github_issues/templates/comment.md
+++ b/src/github_issues/templates/comment.md
@@ -7,3 +7,10 @@ Original Redmine Comment
 ---
 
 {{ description }}
+
+{% if attachments|length > 0 -%}
+---
+{% for attachment in attachments %}
+- [{{ attachment.filename }}]({{ attachment.content_url }}) ({{ attachment.author.name }})
+{%- endfor %}
+{%- endif %}

--- a/src/github_issues/templates/description.md
+++ b/src/github_issues/templates/description.md
@@ -10,5 +10,9 @@
 
 {{ description }}
 
-
-
+{% if attachments|length > 0 -%}
+---
+{% for attachment in attachments %}
+- [{{ attachment.filename }}]({{ attachment.content_url }}) ({{ attachment.author.name }})
+{%- endfor %}
+{%- endif %}

--- a/src/redmine_ticket/redmine_issue_downloader.py
+++ b/src/redmine_ticket/redmine_issue_downloader.py
@@ -280,7 +280,7 @@ print (data['total_count'])
         :returns: json string with issue information
         """
         # test using .issue.get
-        issue = self.redmine_conn.issue.get(issue_id, include='children,journals,watchers,relations')
+        issue = self.redmine_conn.issue.get(issue_id, include='children,attachments,journals,watchers,relations')
         json_str = json.dumps(issue._attributes, indent=4)
         msg('Issue retrieved: %s' % issue_id)
         return json_str


### PR DESCRIPTION
I know this project hasn't been touched in a few years, but I found it really helpful in doing a migration.

I added a couple of other options for migrating attachments (as links back to the original Redmine repository) and project names.